### PR TITLE
Fix pricing so two decimals (and $ and commas) always display properly.

### DIFF
--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -14,8 +14,8 @@
           <%= f.submit "Remove", class: "btn btn-sm btn-danger" %>
           <% end %>
         </td>
-        <td class='price'><span class='price'>$<%= number_with_delimiter(cart_item.price, :delimiter => ',') %></span></td>
-        <td class='price'><span class='price'>$<%= number_with_delimiter(cart_item.total, :delimiter => ',') %></span></td>
+        <td class='price'><span class='price'><%= number_to_currency(cart_item.price) %></span></td>
+        <td class='price'><span class='price'><%= number_to_currency(cart_item.total) %></span></td>
       </tr>
     <% end %>
   </tbody>
@@ -23,7 +23,7 @@
     <td>Total:</td>
     <td></td>
     <td></td>
-    <td class='price'>$<%= number_with_delimiter(@cart_total, :delimiter => ',') %></td>
+    <td class='price'><%= number_to_currency(@cart_total) %></td>
   </tfoot>
 </table>
 

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -2,7 +2,7 @@
   <div class="dad-item panel panel-default">
     <div class="panel-body">
       <%= render partial: "partials/link_summary", locals: {summary: item} %><br>
-      <span class='price'>$<%= number_with_delimiter(item.price, :delimiter => ',') %></span> <br>
+      <span class='price'><%= number_to_currency(item.price) %></span> <br>
       <span class='add_to_cart_button'><%= button_to "Add To Cart", cart_path(item_id: item), class:'btn btn-primary' %></span>
     </div>
   </div>


### PR DESCRIPTION
Used 'number_to_currency' method instead of number_to_delimiter which also handles the commas automatically.

Closes #62