### PR TITLE
Fix item_update_bug

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -9,7 +9,7 @@ class Admin::ItemsController < Admin::AdminController
   end
 
   def update
-    item = Item.find(params[:item][:item_id])
+    item = Item.find_by_dao(params[:id])
     item.update(item_params)
     redirect_to admin_items_path
   end
@@ -25,6 +25,7 @@ class Admin::ItemsController < Admin::AdminController
       redirect_to admin_items_path
     else
       flash[:notice] = item.errors.full_messages
+
       redirect_to new_admin_item_path
     end
   end

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -2,7 +2,8 @@
   <div class='col-md-12'>
     <div class='panel'>
       <div class='panel-body'>
-        <%= form_for @item, url: admin_items_path, method: :html_method  do  |f| %>
+
+        <%= form_for @item, url: admin_item_path(@item), method: html_method do  |f| %>
           <%= f.text_field :name, placeholder: "Name" %>
           <%= f.text_field :description, placeholder: "Description" %>
           <%= f.text_field :price, placeholder: "Price" %>


### PR DESCRIPTION
Fixed local variable name in _form which was :html_method but should be just 'html_method'. Also corrected the path set in the form to be admin_item_path(@item) instead of admin_items_path... and fixed the admin/items controller to find the item by_dao instead of the item id which wasn't actually provided in the params.