### PR TITLE
Fix bug stopping new items to be created

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -28,6 +28,7 @@ class Admin::ItemsController < Admin::AdminController
   def create
     item = Item.new(item_params)
     if item.save
+      flash[:notice] = "New item '#{item.name}' created."
       redirect_to admin_items_path
     else
       flash[:notice] = item.errors.full_messages
@@ -39,6 +40,6 @@ class Admin::ItemsController < Admin::AdminController
 
   def item_params
     params.require(:item).permit(:name, :description, :image_url,
-                                 :category_id, :price, :image_url, :status)
+                                 :category_id, :price, :status)
   end
 end

--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -3,7 +3,7 @@
     <div class='panel'>
       <div class='panel-body'>
 
-        <%= form_for @item, url: admin_item_path(@item), method: html_method do  |f| %>
+        <%= form_for @item, url: path, method: html_method do  |f| %>
           <%= f.text_field :name, placeholder: "Name" %>
           <%= f.text_field :description, placeholder: "Description" %>
           <%= f.text_field :price, placeholder: "Price" %>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -7,4 +7,4 @@
     </div>
   </div>
 </div>
-<%= render partial: 'form', locals: {html_method: :patch} %>
+<%= render partial: 'form', locals: {path: admin_item_path, html_method: :patch} %>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -7,4 +7,4 @@
     </div>
   </div>
 </div>
-<%= render partial: 'form', locals: {html_method: :get} %>
+<%= render partial: 'form', locals: {path: admin_items_path, html_method: :post} %>

--- a/spec/features/admin_items_creation_spec.rb
+++ b/spec/features/admin_items_creation_spec.rb
@@ -37,7 +37,7 @@ feature "admin item creation page" do
     end
   end
 
-  context "as and authenticated admin" do
+  context "as an authenticated admin" do
     before(:each) do
       visit "/"
       click_link("Login")
@@ -46,9 +46,11 @@ feature "admin item creation page" do
       click_button "Login"
       visit "/admin/items/new"
     end
+
     it "returns admin items page" do
       expect(page).not_to have_content(404)
     end
+    
     it "200s" do
       expect(page.status_code).to eq(200)
     end


### PR DESCRIPTION
I think I caused this bugged when fixing the update item bug from before. The create and update actions require different action paths, but they use the same form in which we define that path, so if we defined it to work for create, the update didn't work, and if we defined it properly for update, create didn't work. The solution is a location 'path' variable sent in when the _form partial is called. So, I edited both files adding in the path and changed the _form partial to accept that local variable. Now they both work and the tests are all passing.
